### PR TITLE
Make the library work with my HP Envy 4527 scanner

### DIFF
--- a/escl-scan/src/structs.rs
+++ b/escl-scan/src/structs.rs
@@ -110,7 +110,7 @@ pub struct ScanRegion {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename = "scan:ScanSettings")]
+#[serde(rename = "escl:ScanSettings")]
 pub struct ScanSettings {
     #[serde(rename = "pwg:Version")]
     pub version: String,


### PR DESCRIPTION
I tried to use the library with my scanner but the `/ScanJobs` endpoint
responded with 400 Bad Request. There were a few things I had to fix
to make it work:

- The XML namespace attributes were required for the 'ScanSettings' node
- The prefix for the ‘ScanSettings’ node needed to change to ‘escl’
- The scanner ignores headers that aren't in title case (awful!)

Additionally, I noticed the scanner rejects requests that contain
newline characters.

Hopefully these changes are uncontroversial and should improve support
for other scanners without breaking existing support.